### PR TITLE
export typescript types in package.json

### DIFF
--- a/applicationinsights-react-native/package.json
+++ b/applicationinsights-react-native/package.json
@@ -4,8 +4,14 @@
     "description": "Microsoft Application Insights React Native Plugin",
     "main": "dist-esm/index.js",
     "exports": {
-        ".": "./dist-esm/index.js",
-        "./manual": "./dist-esm/manualIndex.js"
+        ".": {
+            "types": "./types/index.d.ts",
+            "import": "./dist-esm/index.js"
+        },
+        "./manual": {
+            "types": "./types/manualIndex.d.ts",
+            "import": "./dist-esm/manualIndex.js"
+        }
     },
     "types": "types/index.d.ts",
     "sideEffects": false,


### PR DESCRIPTION
When adding this import to a react native project `import {ReactNativePlugin} from '@microsoft/applicationinsights-react-native'`, I get the following error:
```
Could not find a declaration file for module '@microsoft/applicationinsights-react-native'. '/Users/rik/workspace/aapp_app_mobile/node_modules/@microsoft/applicationinsights-react-native/dist-esm/index.js' implicitly has an 'any' type.
  There are types at '/Users/rik/workspace/aapp_app_mobile/node_modules/@microsoft/applicationinsights-react-native/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@microsoft/applicationinsights-react-native' library may need to update its package.json or typings.ts(7016)
```

This can easily be solved be changes the package.json exports. So therefore I made this pull requests.