### PR TITLE
Update example of how to disable device collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,12 @@ appInsights.loadAppInsights();
 ```ts
 import { ApplicationInsights } from '@microsoft/applicationinsights-web';
 
-var RNPlugin = new ReactNativePlugin();
+var RNPlugin = new ReactNativePlugin({
+    disableDeviceCollection: true
+});
 var appInsights = new ApplicationInsights({
     config: {
         instrumentationKey: 'YOUR_INSTRUMENTATION_KEY_GOES_HERE',
-        disableDeviceCollection: true,
         extensions: [RNPlugin]
     }
 });


### PR DESCRIPTION
`disableDeviceCollection` is a property on `ReactNativePlugin` configuration, not `ApplicationInsights` configuration.