### PR TITLE
Fix Jest test mocks

### DIFF
--- a/applicationinsights-react-native/package.json
+++ b/applicationinsights-react-native/package.json
@@ -7,12 +7,11 @@
     ".": {
       "types": "./types/index.d.ts",
       "import": "./dist-esm/index.js",
-      "require": "./dist-esm/index.js"
+      "require": "./dist/applicationinsights-react-native.js"
     },
     "./manual": {
       "types": "./types/manualIndex.d.ts",
-      "import": "./dist-esm/manualIndex.js",
-      "require": "./dist-esm/manualIndex.js"
+      "import": "./dist-esm/manualIndex.js"
     }
   },
   "types": "types/index.d.ts",

--- a/applicationinsights-react-native/package.json
+++ b/applicationinsights-react-native/package.json
@@ -1,97 +1,99 @@
 {
-    "name": "@microsoft/applicationinsights-react-native",
-    "version": "4.3.2",
-    "description": "Microsoft Application Insights React Native Plugin",
-    "main": "dist-esm/index.js",
-    "exports": {
-        ".": {
-            "types": "./types/index.d.ts",
-            "import": "./dist-esm/index.js"
-        },
-        "./manual": {
-            "types": "./types/manualIndex.d.ts",
-            "import": "./dist-esm/manualIndex.js"
-        }
+  "name": "@microsoft/applicationinsights-react-native",
+  "version": "4.3.2",
+  "description": "Microsoft Application Insights React Native Plugin",
+  "main": "dist-esm/index.js",
+  "exports": {
+    ".": {
+      "types": "./types/index.d.ts",
+      "import": "./dist-esm/index.js",
+      "require": "./dist-esm/index.js"
     },
-    "types": "types/index.d.ts",
-    "sideEffects": false,
-    "author": "Microsoft Application Insights Team",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "https://github.com/microsoft/applicationinsights-react-native"
-    },
-    "bugs": {
-        "url": "https://github.com/microsoft/applicationinsights-react-native/issues"
-    },
-    "homepage": "https://github.com/microsoft/applicationinsights-react-native#readme",
-    "keywords": [
-        "performance monitoring",
-        "application insights",
-        "microsoft",
-        "azure",
-        "react native"
-    ],
-    "scripts": {
-        "build": "npm run build:esm && npm run build:package && npm run dtsgen",
-        "build:esm": "grunt reactnative",
-        "build:package": "rollup -c",
-        "rebuild": "npm run build",
-        "test": "grunt reactnativetests",
-        "mintest": "grunt reactnative-mintests",
-        "testx": "npm run build:test && grunt reactnativetests",
-        "lint": "tslint -p tsconfig.json",
-        "dtsgen": "api-extractor run --local && node ../scripts/dtsgen.js \"Microsoft Application Insights react native plugin\"",
-        "ai-min": "grunt reactnative-min",
-        "ai-restore": "grunt reactnative-restore"
-    },
-    "devDependencies": {
-        "@microsoft/ai-test-framework": "0.0.1",
-        "@microsoft/applicationinsights-rollup-es3": "1.1.3",
-        "@microsoft/api-extractor": "^7.18.1",
-        "grunt": "^1.5.3",
-        "grunt-cli": "^1.4.3",
-        "grunt-contrib-qunit": "^5.0.1",
-        "grunt-contrib-uglify": "^5.0.1",
-        "@nevware21/grunt-ts-plugin": "^0.4.3",
-        "@nevware21/grunt-eslint-ts": "^0.2.2",
-        "@typescript-eslint/eslint-plugin": "^4.28.0",
-        "@typescript-eslint/parser": "^4.28.0",
-        "eslint": "^7.29.0",
-        "eslint-config-standard": "^16.0.3",
-        "eslint-plugin-import": "^2.23.4",
-        "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^5.1.0",
-        "qunit": "^2.11.2",
-        "react": "^18.0.0",
-        "react-native": "^0.69.9",
-        "globby": "^11.0.0",
-        "magic-string": "^0.25.7",
-        "@rollup/plugin-commonjs": "^18.0.0",
-        "@rollup/plugin-node-resolve": "^11.2.1",
-        "@rollup/plugin-replace": "^2.3.3",
-        "rollup-plugin-cleanup": "^3.2.1",
-        "rollup-plugin-peer-deps-external": "^2.2.4",
-        "rollup": "^2.77.2",
-        "typescript": "^4.3.4",
-        "tslib": "^2.0.0",
-        "uglify-js": "3.16.0"
-    },
-    "dependencies": {
-        "@microsoft/applicationinsights-common": "^3.3.2",
-        "@microsoft/applicationinsights-core-js": "^3.3.2",
-        "@microsoft/applicationinsights-shims": "^3.0.1",
-        "@microsoft/dynamicproto-js": "^2.0.3",
-        "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
-    },
-    "peerDependencies": {
-        "tslib": "*",
-        "react-native": "*",
-        "react-native-device-info": ">=5.2.1"
-    },
-    "peerDependenciesMeta": {
-        "react-native-device-info": {
-            "optional": true
-        }
+    "./manual": {
+      "types": "./types/manualIndex.d.ts",
+      "import": "./dist-esm/manualIndex.js",
+      "require": "./dist-esm/manualIndex.js"
     }
+  },
+  "types": "types/index.d.ts",
+  "sideEffects": false,
+  "author": "Microsoft Application Insights Team",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/microsoft/applicationinsights-react-native"
+  },
+  "bugs": {
+    "url": "https://github.com/microsoft/applicationinsights-react-native/issues"
+  },
+  "homepage": "https://github.com/microsoft/applicationinsights-react-native#readme",
+  "keywords": [
+    "performance monitoring",
+    "application insights",
+    "microsoft",
+    "azure",
+    "react native"
+  ],
+  "scripts": {
+    "build": "npm run build:esm && npm run build:package && npm run dtsgen",
+    "build:esm": "grunt reactnative",
+    "build:package": "rollup -c",
+    "rebuild": "npm run build",
+    "test": "grunt reactnativetests",
+    "mintest": "grunt reactnative-mintests",
+    "testx": "npm run build:test && grunt reactnativetests",
+    "lint": "tslint -p tsconfig.json",
+    "dtsgen": "api-extractor run --local && node ../scripts/dtsgen.js \"Microsoft Application Insights react native plugin\"",
+    "ai-min": "grunt reactnative-min",
+    "ai-restore": "grunt reactnative-restore"
+  },
+  "devDependencies": {
+    "@microsoft/ai-test-framework": "0.0.1",
+    "@microsoft/applicationinsights-rollup-es3": "1.1.3",
+    "@microsoft/api-extractor": "^7.18.1",
+    "grunt": "^1.5.3",
+    "grunt-cli": "^1.4.3",
+    "grunt-contrib-qunit": "^5.0.1",
+    "grunt-contrib-uglify": "^5.0.1",
+    "@nevware21/grunt-ts-plugin": "^0.4.3",
+    "@nevware21/grunt-eslint-ts": "^0.2.2",
+    "@typescript-eslint/eslint-plugin": "^4.28.0",
+    "@typescript-eslint/parser": "^4.28.0",
+    "eslint": "^7.29.0",
+    "eslint-config-standard": "^16.0.3",
+    "eslint-plugin-import": "^2.23.4",
+    "eslint-plugin-node": "^11.1.0",
+    "eslint-plugin-promise": "^5.1.0",
+    "qunit": "^2.11.2",
+    "react": "^18.0.0",
+    "react-native": "^0.69.9",
+    "globby": "^11.0.0",
+    "magic-string": "^0.25.7",
+    "@rollup/plugin-commonjs": "^18.0.0",
+    "@rollup/plugin-node-resolve": "^11.2.1",
+    "@rollup/plugin-replace": "^2.3.3",
+    "rollup-plugin-cleanup": "^3.2.1",
+    "rollup-plugin-peer-deps-external": "^2.2.4",
+    "rollup": "^2.77.2",
+    "typescript": "^4.3.4",
+    "tslib": "^2.0.0",
+    "uglify-js": "3.16.0"
+  },
+  "dependencies": {
+    "@microsoft/applicationinsights-common": "^3.3.2",
+    "@microsoft/applicationinsights-core-js": "^3.3.2",
+    "@microsoft/applicationinsights-shims": "^3.0.1",
+    "@microsoft/dynamicproto-js": "^2.0.3",
+    "@nevware21/ts-utils": ">= 0.11.3 < 2.x"
+  },
+  "peerDependencies": {
+    "tslib": "*",
+    "react-native": "*",
+    "react-native-device-info": ">=5.2.1"
+  },
+  "peerDependenciesMeta": {
+    "react-native-device-info": {
+      "optional": true
+    }
+  }
 }


### PR DESCRIPTION
### Issue

Version `4.3.0` changed how files were exported in the `package.json` as you can see [in this commit](https://github.com/microsoft/applicationinsights-react-native/commit/e4d244034aff6fcd8707ac864a0bbde7a7b6ffee). If you were mocking the library on Jest so tests could pass, the new configuration wasn't allowing Jest to find the package to be mocked.

![Screenshot 2024-09-10 at 09 56 34](https://github.com/user-attachments/assets/2b771811-ca43-4cb2-9af5-31e26580a543)

### Solution

Adding `require` to to each of the `exports` solves the issue and allows Jest to work again.