### PR TITLE
Fix audit vulnerabilities and Puppeteer WDAC block on managed dev machines

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -2,6 +2,30 @@ module.exports = function (grunt) {
 
    const versionPlaceholder = '"#version#"';
 
+    // Resolve a Puppeteer executable for local dev where managed-device Defender/WDAC
+    // blocks Puppeteer's unsigned bundled Chromium (Windows "blocked by IT admin" popups).
+    // Falls back to installed Edge locally. On CI/official builds it returns undefined so
+    // the bundled Chromium is used unchanged.
+    function _getBrowserExecutablePath() {
+        if (process.env.PUPPETEER_EXECUTABLE_PATH) {
+            return process.env.PUPPETEER_EXECUTABLE_PATH;
+        }
+        if (process.env.TF_BUILD || process.env.CI || process.env.BUILD_BUILDID) {
+            return undefined; // CI / official build => use bundled Chromium
+        }
+        var candidates = [
+            process.env["ProgramFiles(x86)"] + "\\Microsoft\\Edge\\Application\\msedge.exe",
+            process.env["ProgramFiles"] + "\\Microsoft\\Edge\\Application\\msedge.exe"
+        ];
+        for (var i = 0; i < candidates.length; i++) {
+            if (candidates[i] && grunt.file.exists(candidates[i])) {
+                return candidates[i];
+            }
+        }
+        return undefined;
+    }
+    var browserExecutablePath = _getBrowserExecutablePath();
+
    const aiCoreDefaultNameReplacements = [
    ];
 
@@ -256,6 +280,7 @@ module.exports = function (grunt) {
                                 headless: true, 
                                 timeout: 30000,
                                 ignoreHTTPErrors: true,
+                                executablePath: browserExecutablePath,
                                 args:[
                                     "--enable-precise-memory-info",
                                     "--expose-internals-for-testing",
@@ -304,6 +329,7 @@ module.exports = function (grunt) {
                                 headless: true, 
                                 timeout: 30000,
                                 ignoreHTTPErrors: true,
+                                executablePath: browserExecutablePath,
                                 args:[
                                     "--enable-precise-memory-info",
                                     "--expose-internals-for-testing",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2890,7 +2890,7 @@
         "node_modules/@jridgewell/source-map": {
             "version": "0.3.11",
             "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.11.tgz",
-            "integrity": "sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==",
+            "integrity": "sha1-shg1y9Nttla4V8KtAuvUE8wTqbo=",
             "license": "MIT",
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.5",
@@ -3286,7 +3286,7 @@
         "node_modules/@react-native-community/cli-doctor": {
             "version": "8.0.6",
             "resolved": "https://registry.npmjs.org/@react-native-community/cli-doctor/-/cli-doctor-8.0.6.tgz",
-            "integrity": "sha512-ZQqyT9mJMVeFEVIwj8rbDYGCA2xXjJfsQjWk2iTRZ1CFHfhPSUuUiG8r6mJmTinAP9t+wYcbbIYzNgdSUKnDMw==",
+            "integrity": "sha1-lUJQFVqy86ZqVIIeBxvEpjHS3/8=",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -3344,7 +3344,7 @@
         "node_modules/@react-native-community/cli-hermes": {
             "version": "8.0.5",
             "resolved": "https://registry.npmjs.org/@react-native-community/cli-hermes/-/cli-hermes-8.0.5.tgz",
-            "integrity": "sha512-Zm0wM6SfgYAEX1kfJ1QBvTayabvh79GzmjHyuSnEROVNPbl4PeCG4WFbwy489tGwOP9Qx9fMT5tRIFCD8bp6/g==",
+            "integrity": "sha1-Y57cawznP3BeS3N+PeHMR9QlFv8=",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -3428,7 +3428,7 @@
         "node_modules/@react-native-community/cli-plugin-metro": {
             "version": "8.0.7",
             "resolved": "https://registry.npmjs.org/@react-native-community/cli-plugin-metro/-/cli-plugin-metro-8.0.7.tgz",
-            "integrity": "sha512-RK08Fqh//+9nDntCeKBq2LskWp4rD64q56/PxboZZBu5Z8KANJ4OBUzBLxm0rD0h+l9j6AASlO907HooBTWxrA==",
+            "integrity": "sha1-7OlbYs1Sm835FuhjOQmm13eMGjo=",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -3657,7 +3657,7 @@
         "node_modules/@react-native/community-cli-plugin": {
             "version": "0.85.3",
             "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.85.3.tgz",
-            "integrity": "sha512-fs85dmbIqNmtzEixDb0g+q6R3Vt4H9eAt8/inIZdDKfjN76+sUJA2r1nxODQ76bU23MrIbz8sI7KFBPaWk/zQw==",
+            "integrity": "sha1-vJAI/oI7ygWaszCGElPpvlf4zEY=",
             "license": "MIT",
             "dependencies": {
                 "@react-native/dev-middleware": "0.85.3",
@@ -3685,12 +3685,12 @@
             }
         },
         "node_modules/@react-native/community-cli-plugin/node_modules/@babel/code-frame": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-            "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+            "integrity": "sha1-8vu/6ofESiFZDsUVt3iywm2IZuc=",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/helper-validator-identifier": "^7.29.7",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -3701,7 +3701,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/@jest/types": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+            "integrity": "sha1-ETH4z2NOfoTF53urEvBSr1hfulk=",
             "license": "MIT",
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
@@ -3718,7 +3718,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/@types/yargs": {
             "version": "17.0.35",
             "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
-            "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+            "integrity": "sha1-BwE+RqpNfX1QpJ4VYEwcU0DU6yQ=",
             "license": "MIT",
             "dependencies": {
                 "@types/yargs-parser": "*"
@@ -3727,7 +3727,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/accepts": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "integrity": "sha1-u89LpQdUZ/PyEx6rPP/HPC9deJU=",
             "license": "MIT",
             "dependencies": {
                 "mime-types": "^3.0.0",
@@ -3740,7 +3740,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/ansi-styles": {
             "version": "5.2.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-            "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+            "integrity": "sha1-B0SWkK1Fd30ZJKwquy/IiV26g2s=",
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -3752,13 +3752,13 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/hermes-estree": {
             "version": "0.35.0",
             "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
-            "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+            "integrity": "sha1-dnzOCxSmi0vAbNXbfv6In2GIxWU=",
             "license": "MIT"
         },
         "node_modules/@react-native/community-cli-plugin/node_modules/hermes-parser": {
             "version": "0.35.0",
             "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
-            "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+            "integrity": "sha1-diXsLzSriXwqF6e+qXiNE21f2Mk=",
             "license": "MIT",
             "dependencies": {
                 "hermes-estree": "0.35.0"
@@ -3767,7 +3767,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/image-size": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
-            "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+            "integrity": "sha1-7hGK7f5mbbGm7hK+1YIc3jdAJ20=",
             "license": "MIT",
             "dependencies": {
                 "queue": "6.0.2"
@@ -3782,7 +3782,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/jest-get-type": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
-            "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
+            "integrity": "sha1-NvSZ/c6hl8EEWhJzGcBIFyOQj9E=",
             "license": "MIT",
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -3791,7 +3791,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/jest-util": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-            "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+            "integrity": "sha1-I8K2K/sivoK0TemAVYAv83EPwLw=",
             "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
@@ -3808,7 +3808,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/jest-util/node_modules/ci-info": {
             "version": "3.9.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+            "integrity": "sha1-QnmmICinsfJi80c/yWBfXiGMWbQ=",
             "funding": [
                 {
                     "type": "github",
@@ -3823,7 +3823,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/jest-validate": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
-            "integrity": "sha512-ZB7wHqaRGVw/9hST/OuFUReG7M8vKeq0/J2egIGLdvjHCmYqGARhzXmtgi+gVeZ5uXFF219aOc3Ls2yLg27tkw==",
+            "integrity": "sha1-e/cFURxk2lkdRrFfzkFADVIUfZw=",
             "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
@@ -3840,7 +3840,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/jest-worker": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-            "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+            "integrity": "sha1-rK0HOsu663JivVOJ4bz0PhAFjUo=",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
@@ -3855,7 +3855,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/metro": {
             "version": "0.84.4",
             "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz",
-            "integrity": "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==",
+            "integrity": "sha1-38+Ss7ytznyvrxofojG2SQ3654w=",
             "license": "MIT",
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
@@ -3908,7 +3908,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/metro-babel-transformer": {
             "version": "0.84.4",
             "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.4.tgz",
-            "integrity": "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==",
+            "integrity": "sha1-LX3pvU5ZmMjAUw/gXu9xTXwQ+c8=",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.25.2",
@@ -3924,7 +3924,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/metro-cache": {
             "version": "0.84.4",
             "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.4.tgz",
-            "integrity": "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==",
+            "integrity": "sha1-AmR27bYpqEZQ79e0JFu8YAs7Drc=",
             "license": "MIT",
             "dependencies": {
                 "exponential-backoff": "^3.1.1",
@@ -3939,7 +3939,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/metro-cache-key": {
             "version": "0.84.4",
             "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.4.tgz",
-            "integrity": "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==",
+            "integrity": "sha1-UgWdMtpo7y4G1aPUdw3v3G2LrXc=",
             "license": "MIT",
             "dependencies": {
                 "flow-enums-runtime": "^0.0.6"
@@ -3951,7 +3951,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/metro-config": {
             "version": "0.84.4",
             "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz",
-            "integrity": "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==",
+            "integrity": "sha1-RWGQuYSkzhbrEESKPHJogM7Ilek=",
             "license": "MIT",
             "dependencies": {
                 "connect": "^3.6.5",
@@ -3970,7 +3970,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/metro-core": {
             "version": "0.84.4",
             "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz",
-            "integrity": "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==",
+            "integrity": "sha1-5K//q5vS6bMEyJxZMiNE1ZkRwxs=",
             "license": "MIT",
             "dependencies": {
                 "flow-enums-runtime": "^0.0.6",
@@ -3984,7 +3984,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/metro-resolver": {
             "version": "0.84.4",
             "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.4.tgz",
-            "integrity": "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==",
+            "integrity": "sha1-iBgTAau5tHYHLoJj97O5GNSTkxo=",
             "license": "MIT",
             "dependencies": {
                 "flow-enums-runtime": "^0.0.6"
@@ -3996,7 +3996,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/metro-runtime": {
             "version": "0.84.4",
             "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
-            "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
+            "integrity": "sha1-jBCkiNGaSdZLzHdQOQMrYczrJqY=",
             "license": "MIT",
             "dependencies": {
                 "@babel/runtime": "^7.25.0",
@@ -4009,7 +4009,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/metro-source-map": {
             "version": "0.84.4",
             "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
-            "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
+            "integrity": "sha1-4W58Lc4i2K6lJ/RZuoj1ooJ7oyo=",
             "license": "MIT",
             "dependencies": {
                 "@babel/traverse": "^7.29.0",
@@ -4029,7 +4029,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/metro-symbolicate": {
             "version": "0.84.4",
             "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
-            "integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
+            "integrity": "sha1-DVqf0vFbXAeQUAUdi9H4hybW4NI=",
             "license": "MIT",
             "dependencies": {
                 "flow-enums-runtime": "^0.0.6",
@@ -4049,7 +4049,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/metro-transform-plugins": {
             "version": "0.84.4",
             "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.4.tgz",
-            "integrity": "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==",
+            "integrity": "sha1-taTkMpse4CYfsh+JEN9+79AuaF0=",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.25.2",
@@ -4066,7 +4066,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/metro-transform-worker": {
             "version": "0.84.4",
             "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.4.tgz",
-            "integrity": "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==",
+            "integrity": "sha1-KmbWXRR/eqfRPIYg5lR0CV9GtEE=",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.25.2",
@@ -4090,7 +4090,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/mime-types": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
-            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "integrity": "sha1-OQAtQYJXXVrwNv+hGBAPJSSy4qs=",
             "license": "MIT",
             "dependencies": {
                 "mime-db": "^1.54.0"
@@ -4106,7 +4106,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/negotiator": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "integrity": "sha1-tskbtHFy1p+Tz9fDV7u1KQGbX2o=",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -4115,7 +4115,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/ob1": {
             "version": "0.84.4",
             "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
-            "integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
+            "integrity": "sha1-7GRd6/X72FEdwfAL9FTiMvugKps=",
             "license": "MIT",
             "dependencies": {
                 "flow-enums-runtime": "^0.0.6"
@@ -4127,7 +4127,7 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/pretty-format": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
-            "integrity": "sha512-Pdlw/oPxN+aXdmM9R00JVC9WVFoCLTKJvDVLgmJ+qAffBMxsV85l/Lu7sNx4zSzPyoL2euImuEwHhOXdEgNFZQ==",
+            "integrity": "sha1-ykLHWDEPNlv6caC9oKgHFgt3aBI=",
             "license": "MIT",
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
@@ -4141,13 +4141,13 @@
         "node_modules/@react-native/community-cli-plugin/node_modules/react-is": {
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
-            "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+            "integrity": "sha1-6DVX3BLq5jqZ4AOkY4ix3LtE234=",
             "license": "MIT"
         },
         "node_modules/@react-native/community-cli-plugin/node_modules/source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-            "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+            "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
@@ -4268,7 +4268,7 @@
         "node_modules/@react-native/virtualized-lists": {
             "version": "0.85.3",
             "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.85.3.tgz",
-            "integrity": "sha512-dsCjI//OIPEUJMyNHp4l7zNLVjCx7bcaRUceOCkU+IB17hkbtbGWvi7HjGFSzy7FJGmS/MOlcfpb72xXiy1Oig==",
+            "integrity": "sha1-D+R4oQUF1/08/TneJrZnOh/Q4JE=",
             "license": "MIT",
             "dependencies": {
                 "invariant": "^2.2.4",
@@ -5210,6 +5210,346 @@
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/@typescript/typescript-aix-ppc64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+            "integrity": "sha1-zcfOgdYPHgkDSWDd+x+4gNendrY=",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-darwin-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+            "integrity": "sha1-pV/fz6WN9Y0n2yI3zealweNacjU=",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-darwin-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+            "integrity": "sha1-ONHJFygAqR1we+xk0qNwoBZjTbQ=",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-freebsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+            "integrity": "sha1-8f+IEAMLNdK1vg22otxlBGDqlPo=",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-freebsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+            "integrity": "sha1-PYawPzU8WxupUWLrbONVM7/ClL0=",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-arm": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+            "integrity": "sha1-rZS0HhruKk3MaimMe2fEM0X94y4=",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+            "integrity": "sha1-2TNNltbaxv+F2pyGVYiUjek56R8=",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-loong64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+            "integrity": "sha1-KWWu5PyHM2ATnYk9qv5jl6KROK0=",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-mips64el": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+            "integrity": "sha1-Goh6MRvtOoM/gL/Uqe03wnGTbPA=",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-ppc64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+            "integrity": "sha1-i2PJsvRFs5PrTkPsIdoiXa3jV30=",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-riscv64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+            "integrity": "sha1-tuijXCibPql6kqQdRhqu7Q07NuE=",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-s390x": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+            "integrity": "sha1-Lvlmk75IYfbReWVCflsAnLvtGj4=",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-linux-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+            "integrity": "sha1-cyacsLq6UK6gygYERaa4jlg/HOI=",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-netbsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+            "integrity": "sha1-OjZJ+X+vohC05uN5jBXgZgXIqQE=",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-netbsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+            "integrity": "sha1-R+xZSRpAxHDSgH3E0rglUo/Zeas=",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-openbsd-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+            "integrity": "sha1-eWvo2gvZidij+5bygB44qDZbS68=",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-openbsd-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+            "integrity": "sha1-03/ipynrlCwHbEVO5/GBX699Vg8=",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-sunos-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+            "integrity": "sha1-q6jTRkw1ZacER4m6upaRa9SrLIg=",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-win32-arm64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+            "integrity": "sha1-ud5QoXGWOD9iYgtfnQovNK07YNc=",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
+            }
+        },
+        "node_modules/@typescript/typescript-win32-x64": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+            "integrity": "sha1-zzt7DWzlY12spMjgHBic3N5H7Dw=",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "Apache-2.0",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=16.20.0"
             }
         },
         "node_modules/@ungap/structured-clone": {
@@ -6214,9 +6554,9 @@
             }
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.14",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-            "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+            "version": "1.1.18",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+            "integrity": "sha1-POdNiYhRNr4VNTQfjD1EJcKaXKs=",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -8195,9 +8535,9 @@
             }
         },
         "node_modules/eslint/node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
             "dev": true,
             "funding": [
                 {
@@ -8600,7 +8940,7 @@
         "node_modules/exponential-backoff": {
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
-            "integrity": "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==",
+            "integrity": "sha1-Uc+SwcBJPHZgU/nTq+5ENMJE0vY=",
             "license": "Apache-2.0"
         },
         "node_modules/extend": {
@@ -8747,9 +9087,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha1-YQ83QZoDAnBDDOzWjXTj1NlnJdA=",
             "dev": true,
             "funding": [
                 {
@@ -9463,9 +9803,9 @@
             "license": "MIT"
         },
         "node_modules/grunt": {
-            "version": "1.6.2",
-            "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.2.tgz",
-            "integrity": "sha512-bUzh5nA/P5L66ihXTDP6J5BGnMB/8lXJXejYWSbH4Y4TvWM9t2S39sggQDYYQlx06cYcCsmu63HMYHGCIzUVfg==",
+            "version": "1.6.3",
+            "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.6.3.tgz",
+            "integrity": "sha1-P9CQtUKeWPcm9ExF3j9yjSfemIk=",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -9480,7 +9820,7 @@
                 "grunt-legacy-log": "~3.0.0",
                 "grunt-legacy-util": "~2.0.1",
                 "iconv-lite": "~0.6.3",
-                "js-yaml": "~3.14.0",
+                "js-yaml": "^3.15.0",
                 "minimatch": "^3.1.5",
                 "nopt": "^5.0.0"
             },
@@ -10025,7 +10365,7 @@
         "node_modules/image-size": {
             "version": "0.6.3",
             "resolved": "https://registry.npmjs.org/image-size/-/image-size-0.6.3.tgz",
-            "integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA==",
+            "integrity": "sha1-5+XGW7U0vXzc7dbLUWYnKoX3X7I=",
             "devOptional": true,
             "license": "MIT",
             "bin": {
@@ -10131,14 +10471,14 @@
         "node_modules/ip": {
             "version": "1.1.9",
             "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-            "integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
+            "integrity": "sha1-jfvMmadU0H9CUxC4aplUaxFR45Y=",
             "devOptional": true,
             "license": "MIT"
         },
         "node_modules/ip-address": {
-            "version": "10.2.0",
-            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-            "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+            "integrity": "sha1-xZELxUG26uKHdl0eSEa+AwigXZM=",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -11014,9 +11354,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha1-JLyVAo82HNqqhHRbBqEJxEhnc8A=",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -11043,7 +11383,7 @@
         "node_modules/jscodeshift": {
             "version": "0.13.1",
             "resolved": "https://registry.npmjs.org/jscodeshift/-/jscodeshift-0.13.1.tgz",
-            "integrity": "sha512-lGyiEbGOvmMRKgWk4vf+lUrCWO/8YR8sUR3FKF1Cq5fovjZDlIcw3Hu5ppLHAnEXshVffvaM0eyuY/AbOeYpnQ==",
+            "integrity": "sha1-ab/lHlTIMSljgFhcbZ5zNRKuze8=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11077,7 +11417,7 @@
         "node_modules/jscodeshift/node_modules/braces": {
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+            "integrity": "sha1-WXn9PxTNUxVl5fot8av/8d+u5yk=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11177,7 +11517,7 @@
         "node_modules/jscodeshift/node_modules/micromatch": {
             "version": "3.1.10",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-            "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+            "integrity": "sha1-cIWbyVyYQJUvNZoGij/En57PrCM=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11952,7 +12292,7 @@
         "node_modules/metro": {
             "version": "0.70.4",
             "resolved": "https://registry.npmjs.org/metro/-/metro-0.70.4.tgz",
-            "integrity": "sha512-4Ff7jfCF7Jr/PVXvRGVRe5Sb0Qhqceh6i18aYEMfCS0pVsZZcTdXxgTdlB9KGnxSVxT8jjViid+oAAvNJcC2ug==",
+            "integrity": "sha1-b4OXSXn2ARbbmszakoSa3w5fcL4=",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -12060,7 +12400,7 @@
         "node_modules/metro-config": {
             "version": "0.70.4",
             "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.70.4.tgz",
-            "integrity": "sha512-9ellClttQyXF5O487OiFNGxM87PSzsx0m61B7vdXzdyXhCwHk1a8J/8zn5WmOa9/Ix2dJ04N32NzeKgMWVhwQw==",
+            "integrity": "sha1-ZKdH78p0P3cv9mJzL7kP8XRHpM4=",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -12087,7 +12427,7 @@
         "node_modules/metro-file-map": {
             "version": "0.84.4",
             "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.4.tgz",
-            "integrity": "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==",
+            "integrity": "sha1-AN8Ig07k00qMFeM0Gf3/WnajSHA=",
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.4.0",
@@ -12107,7 +12447,7 @@
         "node_modules/metro-file-map/node_modules/@jest/types": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.6.3.tgz",
-            "integrity": "sha512-u3UPsIilWKOM3F9CXtrG8LEJmNxwoCQC/XVj4IKYXvvpx7QIi/Kg1LI5uDmDpKlac62NUtX7eLjRh+jVZcLOzw==",
+            "integrity": "sha1-ETH4z2NOfoTF53urEvBSr1hfulk=",
             "license": "MIT",
             "dependencies": {
                 "@jest/schemas": "^29.6.3",
@@ -12124,7 +12464,7 @@
         "node_modules/metro-file-map/node_modules/@types/yargs": {
             "version": "17.0.35",
             "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
-            "integrity": "sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==",
+            "integrity": "sha1-BwE+RqpNfX1QpJ4VYEwcU0DU6yQ=",
             "license": "MIT",
             "dependencies": {
                 "@types/yargs-parser": "*"
@@ -12133,7 +12473,7 @@
         "node_modules/metro-file-map/node_modules/ci-info": {
             "version": "3.9.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+            "integrity": "sha1-QnmmICinsfJi80c/yWBfXiGMWbQ=",
             "funding": [
                 {
                     "type": "github",
@@ -12148,7 +12488,7 @@
         "node_modules/metro-file-map/node_modules/jest-util": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.7.0.tgz",
-            "integrity": "sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==",
+            "integrity": "sha1-I8K2K/sivoK0TemAVYAv83EPwLw=",
             "license": "MIT",
             "dependencies": {
                 "@jest/types": "^29.6.3",
@@ -12165,7 +12505,7 @@
         "node_modules/metro-file-map/node_modules/jest-worker": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-29.7.0.tgz",
-            "integrity": "sha512-eIz2msL/EzL9UFTFFx7jBTkeZfku0yUAyZZZmJ93H2TYEiroIx2PQjEXcwYtYl8zXCxb+PAmA2hLIt/6ZEkPHw==",
+            "integrity": "sha1-rK0HOsu663JivVOJ4bz0PhAFjUo=",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
@@ -12357,7 +12697,7 @@
         "node_modules/metro-minify-terser": {
             "version": "0.84.4",
             "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.4.tgz",
-            "integrity": "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==",
+            "integrity": "sha1-6QTWPwhdGvM1h/9tr1AQJD0Z7sk=",
             "license": "MIT",
             "dependencies": {
                 "flow-enums-runtime": "^0.0.6",
@@ -12543,7 +12883,7 @@
         "node_modules/metro-transform-worker": {
             "version": "0.70.4",
             "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.70.4.tgz",
-            "integrity": "sha512-N6rVZF1yUi4rnJsG+/e1wyrdpy6s39PzzsvA+gAS4Vxfe0iBo91votavjL4GF+tuekui/PoxOq5nOWo5aRAHhg==",
+            "integrity": "sha1-c5UNgdgstYr88ojw2MjzU2W/+Sg=",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -12888,20 +13228,24 @@
             }
         },
         "node_modules/morgan": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.10.1.tgz",
-            "integrity": "sha512-223dMRJtI/l25dJKWpgij2cMtywuG/WiUKXdvwfbhGKBhy1puASqXwFzmWZ7+K73vUPoR7SS2Qz2cI/g9MKw0A==",
+            "version": "1.11.0",
+            "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.11.0.tgz",
+            "integrity": "sha1-mEZLhTiALxTp5TdOviOsNkzWF+g=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "basic-auth": "~2.0.1",
                 "debug": "2.6.9",
                 "depd": "~2.0.0",
-                "on-finished": "~2.3.0",
+                "on-finished": "~2.4.1",
                 "on-headers": "~1.1.0"
             },
             "engines": {
                 "node": ">= 0.8.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
             }
         },
         "node_modules/morgan/node_modules/debug": {
@@ -12920,6 +13264,19 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/morgan/node_modules/on-finished": {
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+            "integrity": "sha1-WMjEQRblSEWtV/FKsQsDUzGErD8=",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ee-first": "1.1.1"
+            },
+            "engines": {
+                "node": ">= 0.8"
+            }
         },
         "node_modules/ms": {
             "version": "2.1.3",
@@ -14038,7 +14395,7 @@
         "node_modules/pretty-format": {
             "version": "26.6.2",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-26.6.2.tgz",
-            "integrity": "sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==",
+            "integrity": "sha1-41wnBfFMt/4v6U+geDRbREEg/JM=",
             "devOptional": true,
             "license": "MIT",
             "dependencies": {
@@ -14242,9 +14599,9 @@
             }
         },
         "node_modules/puppeteer/node_modules/js-yaml": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-            "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+            "version": "4.3.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+            "integrity": "sha1-ASFsAB1n9I4s1WDXCMevIQkKOEg=",
             "dev": true,
             "funding": [
                 {
@@ -14302,7 +14659,7 @@
         "node_modules/queue": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
-            "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+            "integrity": "sha1-uRUlKD4jFcdVPS76GNg+dkMv7WU=",
             "license": "MIT",
             "dependencies": {
                 "inherits": "~2.0.3"
@@ -14379,34 +14736,12 @@
         "node_modules/react-devtools-core": {
             "version": "4.24.0",
             "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.24.0.tgz",
-            "integrity": "sha512-Rw7FzYOOzcfyUPaAm9P3g0tFdGqGq2LLiAI+wjYcp6CsF3DeeMrRS3HZAho4s273C29G/DJhx0e8BpRE/QZNGg==",
+            "integrity": "sha1-faoZa9xk82JrP1Ty/yuW98T98Bc=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "shell-quote": "^1.6.1",
                 "ws": "^7"
-            }
-        },
-        "node_modules/react-devtools-core/node_modules/ws": {
-            "version": "7.5.11",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-            "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.3.0"
-            },
-            "peerDependencies": {
-                "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
-            },
-            "peerDependenciesMeta": {
-                "bufferutil": {
-                    "optional": true
-                },
-                "utf-8-validate": {
-                    "optional": true
-                }
             }
         },
         "node_modules/react-is": {
@@ -14419,7 +14754,7 @@
         "node_modules/react-native": {
             "version": "0.85.3",
             "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.85.3.tgz",
-            "integrity": "sha512-HN/fGC+3nZVcDNcw7gfbM/DuqZAvI9Mz+/SxuhODaua4JY0BPzhfTzWXRyTR4mRgMHmShTPpH2PYMTxvZrsdZA==",
+            "integrity": "sha1-Sj0lxjov0yD/sJPiAmnPR9WF1IM=",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -14479,7 +14814,7 @@
         "node_modules/react-native-codegen": {
             "version": "0.69.2",
             "resolved": "https://registry.npmjs.org/react-native-codegen/-/react-native-codegen-0.69.2.tgz",
-            "integrity": "sha512-yPcgMHD4mqLbckqnWjFBaxomDnBREfRjDi2G/WxNyPBQLD+PXUEmZTkDx6QoOXN+Bl2SkpnNOSsLE2+/RUHoPw==",
+            "integrity": "sha1-4zrDsUht5Z3a5oe3Md2/zvivDk4=",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -15551,9 +15886,9 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.8.4",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
-            "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+            "integrity": "sha1-SCAz4ZLk9cBxUVIf+gNADscbGw8=",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.4"
@@ -16559,9 +16894,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.47.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
-            "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
+            "version": "5.49.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.49.1.tgz",
+            "integrity": "sha1-ioUdxeY6i+le1OeadaJStfVz52A=",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
@@ -16577,9 +16912,9 @@
             }
         },
         "node_modules/terser/node_modules/acorn": {
-            "version": "8.16.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-            "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+            "integrity": "sha1-T68BstbTJr/u2XrqH1IiC19MGUA=",
             "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
@@ -17793,7 +18128,7 @@
         "node_modules/yaml": {
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+            "integrity": "sha1-eCdK/ZNZih391hMN9qVm3vy/mqQ=",
             "license": "ISC",
             "bin": {
                 "yaml": "bin.mjs"


### PR DESCRIPTION
Security (package-lock.json):
- Apply non-breaking `npm audit fix` (24 -> 17 vulnerabilities); resolves brace-expansion, fast-uri, morgan and shell-quote advisories.
- Normalize lockfile `resolved` URLs back to https://registry.npmjs.org/ so external contributors and public CI are not pinned to an internal npm mirror.
- Remaining advisories are dev-only, transitively pinned by react-native@0.69 (jscodeshift/micromatch/braces, ip, image-size, metro, react-devtools-core) and would require a breaking react-native major upgrade, so they are left as-is.

Puppeteer (gruntfile.js):
- Add a CI-gated helper that resolves the QUnit browser test executable to a locally installed Edge when available, avoiding the Windows "blocked by IT admin" (Defender/WDAC) popup triggered by Puppeteer's unsigned bundled Chromium on managed developer machines.
- Honors PUPPETEER_EXECUTABLE_PATH first and returns undefined on CI/official builds (TF_BUILD/CI/BUILD_BUILDID) so bundled Chromium behavior is unchanged.
- Wire executablePath into both puppeteer test blocks.